### PR TITLE
Add support for specifying a namespace other than default for the destination secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,18 @@ The following commands should undo everything that was created:
 - `kubectl delete -f example/service-account.yml`
 - `kubectl delete secret ecr-renew-cred-demo`
 - `kubectl delete secret ecr-docker-login-demo`
+
+
+### Running in a namespace other than default namespace
+
+You can run this job in multiple, or a specific namespace by passing the environment variable `TARGET_NAMESPACE`, if this option is left empty then the default namespace will be used. You can add this parameter to the example in deploy.yaml with an additional env definition on the container:
+
+```yaml
+- name: ecr-renew
+  image: nabsul/k8s-ecr-login-renew:v0.1
+  env:
+    - name: DOCKER_SECRET_NAME
+      value: ecr-docker-login-demo
+    - name: TARGET_NAMESPACE
+      value: demo-namespace
+```

--- a/example/deploy.yml
+++ b/example/deploy.yml
@@ -16,7 +16,7 @@ spec:
           serviceAccountName: ecr-renew-demo
           containers:
             - name: ecr-renew
-              image: nabsul/k8s-ecr-login-renew:v0.1
+              image: nabsul/k8s-ecr-login-renew:v0.2
               env:
                 - name: DOCKER_SECRET_NAME
                   value: ecr-docker-login-demo

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -30,10 +30,10 @@ func getClient() kubernetes.Clientset {
 	return *client
 }
 
-func deleteOldSecret(client kubernetes.Clientset, name string) {
-	_, err := client.CoreV1().Secrets("default").Get(name, metav1.GetOptions{})
+func deleteOldSecret(client kubernetes.Clientset, name, namespace string) {
+	_, err := client.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
 	if err == nil {
-		err = client.CoreV1().Secrets("default").Delete(name, &metav1.DeleteOptions{})
+		err = client.CoreV1().Secrets(namespace).Delete(name, &metav1.DeleteOptions{})
 		checkErr(err)
 	}
 }
@@ -61,13 +61,13 @@ func createSecret(name, username, password, server string) v1.Secret {
 	return secret
 }
 
-func updatePassword(name, username, password, server string) {
+func updatePassword(name, username, password, server, namespace string) {
 	client := getClient()
 
-	deleteOldSecret(client, name)
+	deleteOldSecret(client, name, namespace)
 
 	secret := createSecret(name, username, password, server)
 
-	_, err := client.CoreV1().Secrets("default").Create(&secret)
+	_, err := client.CoreV1().Secrets(namespace).Create(&secret)
 	checkErr(err)
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 const awsSecretName = "DOCKER_SECRET_NAME"
+const targetNamespaceName = "TARGET_NAMESPACE"
 
 func checkErr(err error) {
 	if err != nil {
@@ -26,12 +27,16 @@ func main() {
 	fmt.Println("Running at " + time.Now().UTC().String())
 
 	name := getEnv(awsSecretName)
+	targetNamespace := getEnv(targetNamespaceName)
+	if targetNamespace == ""{
+		targetNamespace = "default"
+	}
 
 	fmt.Print("Fetching auth data from AWS... ")
 	username, password, server := getUserAndPass()
 	fmt.Println("Success.")
 
 	fmt.Printf("Updating kubernetes secret [%s]... ", name)
-	updatePassword(name, username, password, server)
+	updatePassword(name, username, password, server, targetNamespace)
 	fmt.Println("Success.")
 }


### PR DESCRIPTION
Hi Nabeel,

Firstly thanks for making this tool it's super handy to be able to use ECR images on non-EKS clusters.

Small change to allow specifying a `TARGET_NAMESPACE` environment variable to get the tool to create the secret in the specified namespace. Since `imagePullSecrets` I've been using this small patch to run in each namespace, combined with IAM permissions this lets certain namespaces only have access to certain images.

Regards,
-Smudge