### PR TITLE
Allow additional registries to be specified for the secret

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Push image
       run: |
         VERSION=$(date +%s)
-        IMAGE=docker.pkg.github.com/${GITHUB_REPOSITORY}/k8s-ecr-login-renew:$VERSION
+        REPOSITORY=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+        IMAGE=docker.pkg.github.com/${REPOSITORY}/k8s-ecr-login-renew:$VERSION
         [ "$VERSION" == "master" ] && VERSION=latest
         docker tag k8s-ecr-login-renew $IMAGE
         docker push $IMAGE

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Push image
       run: |
         VERSION=$(date +%s)
-        IMAGE=docker.pkg.github.com/nabsul/k8s-ecr-login-renew/k8s-ecr-login-renew:$VERSION
+        IMAGE=docker.pkg.github.com/${GITHUB_REPOSITORY}/k8s-ecr-login-renew:$VERSION
         [ "$VERSION" == "master" ] && VERSION=latest
         docker tag k8s-ecr-login-renew $IMAGE
         docker push $IMAGE


### PR DESCRIPTION
The returned AWS ECR credentials can potentially be valid for any registry; but, each registry must be specified in the Kubernetes secret for Kubernetes to know to use that secret for that registry.

This PR adds a new environment variable `DOCKER_REGISTRIES`. If set, each registry in that environment variable (comma-delimited) will be added to the docker config secret, in addition to the "default" registry returned via logging-in.