### PR TITLE
🚸 Improve Usability for Multiline Target Namespace Declaration

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func formatNamespaceList(namespaceList string) string{
 
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, " ", "")
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\r", "")
+	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\t", "")
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\n", ",")
 	formattedNamespaceList = strings.TrimSuffix(formattedNamespaceList, ",")
 

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func formatNamespaceList(namespaceList string) string{
 	formattedNamespaceList := namespaceList
 
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, " ", "")
+	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\r", "")
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\n", ",")
 	formattedNamespaceList = strings.TrimSuffix(formattedNamespaceList, ",")
 

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func formatNamespaceList(namespaceList string) string{
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, " ", "")
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\r", "")
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\t", "")
+	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\v", "")
 	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\n", ",")
 	formattedNamespaceList = strings.TrimSuffix(formattedNamespaceList, ",")
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 		panic(fmt.Sprintf("Environment variable %s is required", name))
 	}
 
-	namespaceList := os.Getenv(envVarTargetNamespace)
+	namespaceList := formatNamespaceList(os.Getenv(envVarTargetNamespace))
 	if namespaceList == "" {
 		namespaceList = "default"
 	}
@@ -73,4 +73,14 @@ func getServerList(defaultServer string) []string {
 	}
 
 	return strings.Split(addedServersSetting, ",")
+}
+
+func formatNamespaceList(namespaceList string) string{
+	formattedNamespaceList := namespaceList
+
+	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, " ", "")
+	formattedNamespaceList = strings.ReplaceAll(formattedNamespaceList, "\n", ",")
+	formattedNamespaceList = strings.TrimSuffix(formattedNamespaceList, ",")
+
+	return formattedNamespaceList
 }


### PR DESCRIPTION
## Summary
Added the ability to use Multiline YAML to declare Target Namespaces. When Declaring a large amount of namespaces having all the namespaces in one line can become hard to read, format and track on git. 

I have added the **formatNamespaceList** function that replaces a new line with a comma & removes all whitespace.
This now means we can use Multiline YAML whilst also retaining backwards compatibility and not introduce any breaking changes.

## Examples

- Original Method (Single Namespace)
```yaml 
- name: TARGET_NAMESPACE
  value: namespace1
```

- Original Method (Multi-Namespace)
```yaml
- name: TARGET_NAMESPACE
  value: namespace1,namespace2,namespace3
```

- New Multiline Method (Multi-Namespace)
```yaml
- name: TARGET_NAMESPACE
  value: |
    namespace1
    namespace2
    namespace3
    namespace4
    namespace5
```

## Testing 
I have tested this using both the tests provided in this repo & using this application with these changes in a cluster with 30+ namespaces.
