### PR TITLE
feat: add podAnnotations to the cronjob

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.1
 description: Deploys a cronJob which will renew ECR imagePullSecrets automatically
 name: k8s-ecr-login-renew
-version: 1.0.0
+version: 1.0.1
 maintainers:
 - name: Nabeel Sulieman
   url: https://nabeel.dev

--- a/chart/templates/005-CronJob.yaml
+++ b/chart/templates/005-CronJob.yaml
@@ -19,6 +19,10 @@ spec:
     spec:
       template:
         metadata:
+          annotations: 
+{{- with .Values.podAnnotations }}
+            {{- toYaml . | trim | nindent 12 }}
+{{- end }}
 {{- if .Values.forHelm }}
           labels:
             app.kubernetes.io/name: {{ .Chart.Name }}

--- a/chart/templates/005-CronJob.yaml
+++ b/chart/templates/005-CronJob.yaml
@@ -19,8 +19,8 @@ spec:
     spec:
       template:
         metadata:
-          annotations: 
 {{- with .Values.podAnnotations }}
+          annotations:
             {{- toYaml . | trim | nindent 12 }}
 {{- end }}
 {{- if .Values.forHelm }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -41,3 +41,6 @@ aws:
   secretKeys:
     accessKeyId: 'AWS_ACCESS_KEY_ID'
     secretAccessKey: 'AWS_SECRET_ACCESS_KEY'
+
+# Pod annotations for the pods that are created by the cronjob
+podAnnotations: {}


### PR DESCRIPTION
This is a little bit of high prior PR. This adds the ability to add custom annotations to the pods that the cronjob creates. This is needed for cronjobs executed in namespaces with a service mesh i.e linked and we don't want to add these pods to the mesh. If we cannot add pod annotation and disable the mesh, the mesh sidecar will be running forever and the job will not finish