### PR TITLE
Make the AWS environment variables optional

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-ecr-login-renew
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.7.1
 description: Deploys a cronJob which will renew ECR imagePullSecrets automatically
 maintainers:

--- a/chart/templates/005-CronJob.yaml
+++ b/chart/templates/005-CronJob.yaml
@@ -38,11 +38,11 @@ spec:
           terminationGracePeriodSeconds: {{ required "Termination grace period is required" .Values.cronjob.terminationGracePeriodSeconds }}
           restartPolicy: Never
           containers:
-{{- if .Values.aws -}}
           - name: k8s-ecr-login-renew
             imagePullPolicy: IfNotPresent
             image: {{ required "Docker image must be specficed" .values.cronjob.dockerImage }}
             env:
+{{- if .Values.aws -}}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/005-CronJob.yaml
+++ b/chart/templates/005-CronJob.yaml
@@ -38,6 +38,7 @@ spec:
           terminationGracePeriodSeconds: {{ required "Termination grace period is required" .Values.cronjob.terminationGracePeriodSeconds }}
           restartPolicy: Never
           containers:
+{{- if .Values.aws -}}
           - name: k8s-ecr-login-renew
             imagePullPolicy: IfNotPresent
             image: {{ required "Docker image must be specficed" .values.cronjob.dockerImage }}
@@ -52,6 +53,7 @@ spec:
                 secretKeyRef:
                   name: {{ required "AWS credentials secret name is required" .Values.aws.secretName }}
                   key: {{ required "AWS credentials secret key secret acceess key is required" .Values.aws.secretKeys.secretAccessKey }}
+{{- end -}}
             - name: AWS_REGION
               value: {{ required "AWS region must be specified" .Values.awsRegion }}
             - name: DOCKER_SECRET_NAME

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -55,6 +55,7 @@ names:
 # AWS is accessed using an access key ID and secret access key.
 # You can either pre-populate a Kubernetes secret with this information,
 # or provide them as Helm values for the secret to be automatically created.
+# Set `aws` to null if you will not be authenticating with environment variables.
 aws:
   secretName: 'k8s-ecr-login-renew-aws-secret'
   secretKeys:


### PR DESCRIPTION
This is to allow for other methods of authentication using the AWS SDK's default ordering of methods.