### PR TITLE
fix yaml template error when TARGET_NAMESPACE only contains *

### DIFF
--- a/chart/templates/005-CronJob.yaml
+++ b/chart/templates/005-CronJob.yaml
@@ -59,10 +59,10 @@ spec:
             - name: DOCKER_SECRET_NAME
               value: {{ required "Secret name for Docker credentials is required" .Values.dockerSecretName }}
             - name: TARGET_NAMESPACE
-              value: {{ required "Target namespace is required" .Values.targetNamespace }}
+              value: {{ required "Target namespace is required" .Values.targetNamespace | quote }}
 {{- if .Values.excludeNamespace }}
             - name: EXCLUDE_NAMESPACE
-              value: {{ required "Target namespace is required" .Values.excludeNamespace }}
+              value: {{ required "Target namespace is required" .Values.excludeNamespace | quote }}
 {{- end }}
 {{- if .Values.registries }}
             - name: DOCKER_REGISTRIES


### PR DESCRIPTION
When `targetNamespace` in values.yaml only contains '*', helm will raise error when trying to install or upgrade, ref: https://stackoverflow.com/a/71176695

```
$ helm upgrade --install k8s-ecr-login-renew nabsul/k8s-ecr-login-renew \
    --namespace aws-${awsAccountId} \
    --set "awsAccessKeyId=${awsAccessKeyId}" \
    --set "awsSecretAccessKey=${awsSecretAccessKey}" \
    --values values.aws-${awsAccountId}.yaml --dry-run --debug
history.go:56: [debug] getting history for release k8s-ecr-login-renew
Release "k8s-ecr-login-renew" does not exist. Installing it now.
install.go:214: [debug] Original chart version: ""
install.go:231: [debug] CHART PATH: /home/ak1ra/.cache/helm/repository/k8s-ecr-login-renew-1.0.5.tgz

Error: YAML parse error on k8s-ecr-login-renew/templates/005-CronJob.yaml: error converting YAML to JSON: yaml: line 49: did not find expected alphabetic or numeric character
helm.go:84: [debug] error converting YAML to JSON: yaml: line 49: did not find expected alphabetic or numeric character
YAML parse error on k8s-ecr-login-renew/templates/005-CronJob.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:168
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
        helm.sh/helm/v3/pkg/action/install.go:304
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:306
main.newUpgradeCmd.func2
        helm.sh/helm/v3/cmd/helm/upgrade.go:146
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.7.0/command.go:940
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.7.0/command.go:1068
github.com/spf13/cobra.(*Command).Execute
        github.com/spf13/cobra@v1.7.0/command.go:992
main.main
        helm.sh/helm/v3/cmd/helm/helm.go:83
runtime.main
        runtime/proc.go:250
runtime.goexit
        runtime/asm_amd64.s:1598
```