### PR TITLE
fix: cronjob template was broken using targetNamespace wildcard

### DIFF
--- a/chart/templates/005-CronJob.yaml
+++ b/chart/templates/005-CronJob.yaml
@@ -59,7 +59,7 @@ spec:
             - name: DOCKER_SECRET_NAME
               value: {{ required "Secret name for Docker credentials is required" .Values.dockerSecretName }}
             - name: TARGET_NAMESPACE
-              value: {{ required "Target namespace is required" .Values.targetNamespace }}
+              value: {{ required "Target namespace is required" .Values.targetNamespace | quote }}
 {{- if .Values.excludeNamespace }}
             - name: EXCLUDE_NAMESPACE
               value: {{ required "Target namespace is required" .Values.excludeNamespace }}


### PR DESCRIPTION
I was trying to use a wildcard on the `targetNamespace` and it was not working, helm was complaining until I added the quote.

```sh
helm template . --values values.yaml --values values.yaml
Error: YAML parse error on aws-ecr-login/templates/005-CronJob.yaml: error converting YAML to JSON: yaml: line 49: did not find expected alphabetic or numeric character

Use --debug flag to render out invalid YAML
```