### PR TITLE
Add optional cronjob.concurrencyPolicy and cronjob.activeDeadlineSeconds

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-ecr-login-renew
-version: 1.0.6
+version: 1.1.0
 appVersion: 1.7.2
 description: Deploys a cronJob which will renew ECR imagePullSecrets automatically
 maintainers:

--- a/chart/templates/005-CronJob.yaml
+++ b/chart/templates/005-CronJob.yaml
@@ -18,8 +18,14 @@ spec:
 {{- if .Values.cronjob.startingDeadlineSeconds }}
   startingDeadlineSeconds: {{ .Values.cronjob.startingDeadlineSeconds }}
 {{- end }}
+{{- if .Values.cronjob.concurrencyPolicy }}
+  concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy }}
+{{- end }}
   jobTemplate:
     spec:
+{{- if .Values.cronjob.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.cronjob.activeDeadlineSeconds }}
+{{- end }}
       template:
         metadata:
 {{- with .Values.podAnnotations }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -35,7 +35,15 @@ cronjob:
   # The deadline afterwhich running the cronJob will be skipped. See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-job-limitations for defaults and details.
   startingDeadlineSeconds: null
 
-  # Termination grace period Seconds 
+  # Optional. How to treat concurrent job runs: Allow (default when unset), Forbid, or Replace.
+  # Replace supersedes a still-running job with a new scheduled run instead of letting runs pile up.
+  concurrencyPolicy: null
+
+  # Optional. Deadline (seconds) for a single job run. A run exceeding this is terminated instead of
+  # hanging indefinitely (e.g. when a pod is stuck on a node that cannot start it). Unset = no deadline.
+  activeDeadlineSeconds: null
+
+  # Termination grace period Seconds
   terminationGracePeriodSeconds: 0
 
 # Set this to false in order to generate raw YAML that can be used without Helm


### PR DESCRIPTION
## Summary

Adds two optional CronJob settings as chart values, following the existing optional-field idiom (the same `{{- if .Values.cronjob.X }}` pattern already used for `startingDeadlineSeconds`):

- `cronjob.concurrencyPolicy` — `Allow` | `Forbid` | `Replace` (rendered at the CronJob `spec` level)
- `cronjob.activeDeadlineSeconds` — rendered on the Job template `spec`

Both default to `null` and render **only** when set, so existing installs are completely unchanged.

## Motivation

The renewer runs as a CronJob, and on a cluster where a node's runtime/CNI can't start new pods, a run can hang in `ContainerCreating` indefinitely. With the chart's current fixed behavior (`concurrencyPolicy` defaults to `Allow`, no `activeDeadlineSeconds`), stuck runs pile up and never terminate, so the pull secret silently goes stale. These two knobs make the renewer self-healing:

- `concurrencyPolicy: Replace` → a new scheduled run supersedes a still-running (stuck) one instead of accumulating.
- `activeDeadlineSeconds: 300` → a hung run is terminated so the next schedule can recover.

They can't currently be set without a post-render patch or a fork.

## Testing

`helm template` with a local chart build:
- defaults (both unset) → neither field is rendered (no change to existing behavior).
- `--set cronjob.concurrencyPolicy=Replace --set cronjob.activeDeadlineSeconds=300` → renders `concurrencyPolicy: Replace` at the CronJob spec and `activeDeadlineSeconds: 300` on the job template spec.

## Notes

- `Chart.yaml` bumped `1.0.6 → 1.1.0` — happy to change to match your release conventions.
- Docs added inline in `values.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)